### PR TITLE
Added view port on Mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
         </div>
     </div>
     <canvas id="canvas"></canvas>
+    <!-- to view what would be under your finger on the touchscreen -->
+    <canvas id="mobileViewport" style="position:absolute; top: 0; left: 0; display: none"></canvas>
 </body>
     <script src="fish.js"></script>
     <script src="player.js"></script>

--- a/main.css
+++ b/main.css
@@ -18,7 +18,13 @@ canvas{
     background-color: #000;
     height: 80%;
     position: relative;
-    
+
+  }
+/* for the mobile viewport */
+#mobileViewport{
+    border: 1px blue solid;
+    border-radius: 10px;
+    opacity: 0.5;
   }
 .start-wrapper{
     margin: 0;
@@ -27,7 +33,7 @@ canvas{
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
     text-align: center;
-    width: 100%;    
+    width: 100%;
 }
 .game-title{
     font-size: 3rem;
@@ -38,8 +44,7 @@ canvas{
     font-size: 3rem;
 }
 @keyframes blinker{
-    50% { 
+    50% {
         opacity: 0;
     }
 }
-        

--- a/main.js
+++ b/main.js
@@ -4,6 +4,13 @@ let c = canvas.getContext("2d");
 canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
 
+//setup mobileViewport
+let mobileView = document.getElementById("mobileViewport");
+let mobCon = mobileView.getContext("2d");
+
+mobileView.width = 100;
+mobileView.height = 100;
+
 let game = new Game();
 let controller = new Controller(canvas);
 
@@ -19,8 +26,11 @@ canvas.addEventListener('mousemove', (evt)=>{
 canvas.addEventListener('touchmove', function(e){
     let x,y;
     x = e.changedTouches[0].clientX - canvas.getBoundingClientRect().left;
-    y = e.changedTouches[0].clientY - canvas.getBoundingClientRect().top;    
+    y = e.changedTouches[0].clientY - canvas.getBoundingClientRect().top;
     controller.move(x, y);
+
+    //update mobileViewport; Suggestion: cancel when fish gets X big
+    updateMobView(x, y);
 });
 
 canvas.addEventListener('touchstart', function(e){
@@ -28,6 +38,14 @@ canvas.addEventListener('touchstart', function(e){
     x = e.changedTouches[0].clientX - canvas.getBoundingClientRect().left;
     y = e.changedTouches[0].clientY - canvas.getBoundingClientRect().top;
     controller.move(x, y);
+
+    //update mobileViewport; Suggestion: cancel when fish gets X big
+    updateMobView(x, y);
+});
+
+//to hide the mobileViewport when not in use
+canvas.addEventListener('touchend', function(e){
+    mobileView.style.display = "none";
 });
 
 canvas.addEventListener('click', ()=>{
@@ -45,4 +63,18 @@ function init(){
     document.getElementById('start_screen').style.display = "none";
     canvas.style.display = "block";
     animate();
+}
+
+//updates the mobileViewport with new content based on given x and y coord
+function updateMobView(x, y){
+    mobCon.fillRect(0, 0, mobileView.width, mobileView.height);
+    mobCon.drawImage(canvas, x - 50, y - 50, 100, 100, 0, 0, 100, 100);
+    if (y - 150 >= 0){
+        mobileView.style.top = y - 150 + "px";
+    }
+    else{
+        mobileView.style.top = y + 50 + "px";
+    }
+    mobileView.style.left = x - 50 + "px";
+    mobileView.style.display = "block";
 }


### PR DESCRIPTION
- added extra canvas called mobileViewport
- mobileViewport draws a section of canvas on touchstart and touchend
- allows player to view player fish under their finger
- mobileViewport sits above the finger, unless too high on the screen; 
then, it is below the finger
- transparent to still view other fish under mobileViewport
- doesn't show when using the mouse, only on touch events
- goes away on touchend